### PR TITLE
Using standard port for liquideos endpoint

### DIFF
--- a/src/app/services/scatter.service.ts
+++ b/src/app/services/scatter.service.ts
@@ -20,7 +20,7 @@ export class ScatterService {
     this.network = {
       blockchain:'eos',
       host:'node2.liquideos.com',
-      port:8888,
+      port:80,
       chainId:'aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906'
     };
     this.eos = this.scatter.eos(this.network, Eos, {}, 'http' );


### PR DESCRIPTION
We opened port the standard http/https ports (80/443) for the node2.liquideos.com endpoint. We recommend using them for better connectivity in environments where http ports other than 80 are being blocked. (old ports will continue to work)